### PR TITLE
add limited support for archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Platforms supported:
 * Debian
 * Fedora
 * Alpine
+* Archlinux(limited)
+
+*note*: for archlinux [zef](https://github.com/ugexe/zef) will not be installed because the installer uses a [user](https://spider-mario.quantic-telecom.net/archlinux/rakudo) binary repo without zef package.
 
 # Install
 
@@ -72,7 +75,6 @@ Alexey Melezhik
 # See also
 
 [rakudo-pkg project](https://github.com/nxadm/rakudo-pkg/releases)
-
 
 
 

--- a/examples/install_rakudo.pl6
+++ b/examples/install_rakudo.pl6
@@ -1,0 +1,3 @@
+set_spl %( 'dev-rakudo-install' => 'https://github.com/melezhik/rakudo-install' );
+
+task_run 'install test Rakudo', 'dev-rakudo-install';

--- a/hook.pl
+++ b/hook.pl
@@ -1,5 +1,6 @@
 my $os  = os();
 my $url = config()->{url} || config()->{os_url}->{$os};
+my $repo = config()->{repo}->{$os};
 
 my $file = $url; s{.*/(.*)}[$1] for $file;
 
@@ -11,6 +12,10 @@ while (1){
     run_story("/install/$os_short/", { file => $file })->{status} or last; 
     run_story("/install-zef")->{status} or last; 
     set_stdout("done");
+    last;
+  }
+  elsif ( $os =~ 'archlinux' ) {
+    run_story("/install/$os/", { repo => $repo });
     last;
   } else {
     set_stdout("os $os not supported");

--- a/modules/install/archlinux/story.bash
+++ b/modules/install/archlinux/story.bash
@@ -1,0 +1,16 @@
+set -e
+
+repo=$(story_var repo)
+REPO_CONFIG='/tmp/pacman_rakudo.conf'
+
+cat << PACMAN_ADDITION_CONFIG > $REPO_CONFIG
+Include = /etc/pacman.conf
+[rakudo]
+SigLevel = Optional
+Server = $repo
+PACMAN_ADDITION_CONFIG
+
+pacman -Syy --config $REPO_CONFIG
+pacman -S --noconfirm --config $REPO_CONFIG rakudo
+
+perl6 -v

--- a/modules/install/archlinux/story.check
+++ b/modules/install/archlinux/story.check
@@ -1,0 +1,1 @@
+This is Rakudo version

--- a/suite.yaml
+++ b/suite.yaml
@@ -7,5 +7,8 @@ os_url:
   fedora:   https://github.com/nxadm/rakudo-pkg/releases/download/v2017.11/rakudo-pkg-Fedora25-2017.11-01.x86_64.rpm
   alpine:   https://github.com/nxadm/rakudo-pkg/releases/download/v2017.11/rakudo-pkg-Alpine3.6_2017.11-01_x86_64.apk
 
+repo:
+  archlinux: https://spider-mario.quantic-telecom.net/archlinux/$repo/$arch
+
 sudo: off
 user_install: off


### PR DESCRIPTION
Здравствуйте. У nxadm нет пакета для archlinux. Но один из майнтейнеров пакета rakudo для арча сделал готовый репозиторий с тремя пакетами для perl6 - https://spider-mario.quantic-telecom.net/archlinux/rakudo/x86_64/.
Я добавил в этот скрипт установку через временное подключение этого репозитория. zef необходимо ставить самому.
Добавил пример для теста плагина из git.

вот пример удачной установки - https://gist.github.com/Spigell/77d00a1b04ff423013577d21fcb60bd0

P.S. Я сделал vagrant box 'archlinux-sparrow' (https://app.vagrantup.com/spigell/boxes/archlinux-sparrow). Это самая обычная установка + sparrow. Можете потестить на нем. 
Или используйте стандартный archlinux/archlinux, если будете проверять с vagrant.